### PR TITLE
Fix duplicate symbols in the example project

### DIFF
--- a/Example/M2DWebViewController.xcodeproj/project.pbxproj
+++ b/Example/M2DWebViewController.xcodeproj/project.pbxproj
@@ -23,11 +23,6 @@
 		6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5B8195388D20070C39A /* InfoPlist.strings */; };
 		6003F5BC195388D20070C39A /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F5BB195388D20070C39A /* Tests.m */; };
 		D7327120609861F29FC56149 /* libPods-M2DWebViewController.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E6F64939D387F863473C21F1 /* libPods-M2DWebViewController.a */; };
-		E91E6B3319EC08EA00DBF994 /* M2DWebViewController_left.png in Resources */ = {isa = PBXBuildFile; fileRef = E91E6B2F19EC08EA00DBF994 /* M2DWebViewController_left.png */; };
-		E91E6B3419EC08EA00DBF994 /* M2DWebViewController_left@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E91E6B3019EC08EA00DBF994 /* M2DWebViewController_left@2x.png */; };
-		E91E6B3519EC08EA00DBF994 /* M2DWebViewController_right.png in Resources */ = {isa = PBXBuildFile; fileRef = E91E6B3119EC08EA00DBF994 /* M2DWebViewController_right.png */; };
-		E91E6B3619EC08EA00DBF994 /* M2DWebViewController_right@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E91E6B3219EC08EA00DBF994 /* M2DWebViewController_right@2x.png */; };
-		E99F030519EBFA6A00B76837 /* M2DWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E99F030019EBFA6A00B76837 /* M2DWebViewController.m */; };
 		E99F030919EBFBF400B76837 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E99F030819EBFBF400B76837 /* WebKit.framework */; };
 /* End PBXBuildFile section */
 
@@ -70,12 +65,6 @@
 		A6DF9A72B87EC25E994C0A12 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		AD52DAC5375462DB3670007B /* M2DWebViewController.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = M2DWebViewController.podspec; path = ../M2DWebViewController.podspec; sourceTree = "<group>"; };
 		E6F64939D387F863473C21F1 /* libPods-M2DWebViewController.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-M2DWebViewController.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		E91E6B2F19EC08EA00DBF994 /* M2DWebViewController_left.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = M2DWebViewController_left.png; sourceTree = "<group>"; };
-		E91E6B3019EC08EA00DBF994 /* M2DWebViewController_left@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "M2DWebViewController_left@2x.png"; sourceTree = "<group>"; };
-		E91E6B3119EC08EA00DBF994 /* M2DWebViewController_right.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = M2DWebViewController_right.png; sourceTree = "<group>"; };
-		E91E6B3219EC08EA00DBF994 /* M2DWebViewController_right@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "M2DWebViewController_right@2x.png"; sourceTree = "<group>"; };
-		E99F02FF19EBFA6A00B76837 /* M2DWebViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = M2DWebViewController.h; sourceTree = "<group>"; };
-		E99F030019EBFA6A00B76837 /* M2DWebViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = M2DWebViewController.m; sourceTree = "<group>"; };
 		E99F030819EBFBF400B76837 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		FF8D055741BCBFEF35F99299 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -110,7 +99,6 @@
 		6003F581195388D10070C39A = {
 			isa = PBXGroup;
 			children = (
-				E99F02F819EBFA6A00B76837 /* Pod */,
 				60FF7A9C1954A5C5007DD14C /* Podspec Metadata */,
 				6003F593195388D20070C39A /* M2DWebViewController */,
 				6003F5B5195388D20070C39A /* Tests */,
@@ -208,44 +196,6 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		E99F02F819EBFA6A00B76837 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				E99F02F919EBFA6A00B76837 /* Assets */,
-				E99F02FB19EBFA6A00B76837 /* Classes */,
-			);
-			name = Pod;
-			path = ../Pod;
-			sourceTree = "<group>";
-		};
-		E99F02F919EBFA6A00B76837 /* Assets */ = {
-			isa = PBXGroup;
-			children = (
-				E91E6B2F19EC08EA00DBF994 /* M2DWebViewController_left.png */,
-				E91E6B3019EC08EA00DBF994 /* M2DWebViewController_left@2x.png */,
-				E91E6B3119EC08EA00DBF994 /* M2DWebViewController_right.png */,
-				E91E6B3219EC08EA00DBF994 /* M2DWebViewController_right@2x.png */,
-			);
-			path = Assets;
-			sourceTree = "<group>";
-		};
-		E99F02FB19EBFA6A00B76837 /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				E99F02FD19EBFA6A00B76837 /* M2DWebViewController */,
-			);
-			path = Classes;
-			sourceTree = "<group>";
-		};
-		E99F02FD19EBFA6A00B76837 /* M2DWebViewController */ = {
-			isa = PBXGroup;
-			children = (
-				E99F02FF19EBFA6A00B76837 /* M2DWebViewController.h */,
-				E99F030019EBFA6A00B76837 /* M2DWebViewController.m */,
-			);
-			path = M2DWebViewController;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -327,13 +277,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E91E6B3519EC08EA00DBF994 /* M2DWebViewController_right.png in Resources */,
 				6003F5A9195388D20070C39A /* Images.xcassets in Resources */,
-				E91E6B3419EC08EA00DBF994 /* M2DWebViewController_left@2x.png in Resources */,
 				6003F5A1195388D20070C39A /* Main.storyboard in Resources */,
-				E91E6B3319EC08EA00DBF994 /* M2DWebViewController_left.png in Resources */,
 				6003F598195388D20070C39A /* InfoPlist.strings in Resources */,
-				E91E6B3619EC08EA00DBF994 /* M2DWebViewController_right@2x.png in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -416,7 +362,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				6003F59E195388D20070C39A /* M2DAppDelegate.m in Sources */,
-				E99F030519EBFA6A00B76837 /* M2DWebViewController.m in Sources */,
 				6003F5A7195388D20070C39A /* M2DViewController.m in Sources */,
 				6003F59A195388D20070C39A /* main.m in Sources */,
 			);
@@ -488,6 +433,7 @@
 				COPY_PHASE_STRIP = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -527,6 +473,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,0 +1,17 @@
+PODS:
+  - Kiwi (2.3.1)
+  - M2DWebViewController (0.1.2)
+
+DEPENDENCIES:
+  - Kiwi
+  - M2DWebViewController (from `../`)
+
+EXTERNAL SOURCES:
+  M2DWebViewController:
+    :path: ../
+
+SPEC CHECKSUMS:
+  Kiwi: 73e1400209055ee9c8ba78c6012b6b642d0fb9f7
+  M2DWebViewController: 66336de00ad5cf46e6531940597774825135cde5
+
+COCOAPODS: 0.35.0

--- a/Pod/Classes/M2DWebViewController/M2DWebViewController.m
+++ b/Pod/Classes/M2DWebViewController/M2DWebViewController.m
@@ -37,7 +37,8 @@ static NSString *const kM2DWebViewControllerGetTitleScript = @"var elements=docu
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-	
+    self.title = NSLocalizedString(@"Loading...", @"");
+
 #if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_8_0
 	type_ = M2DWebViewTypeUIKit;
 #endif


### PR DESCRIPTION
Remove the duplicate symbols of `_OBJC_IVAR_$_M2DWebViewController` referenced in `M2DWebViewController.xcodeproj` since it would be included in `Pods.xcodeproj` after running `pod install`.
